### PR TITLE
feat: #3 - cambio_titulo

### DIFF
--- a/app_docs/conditional_docs.md
+++ b/app_docs/conditional_docs.md
@@ -22,3 +22,9 @@ Este documento te ayuda a determinar que documentacion deberias leer en funcion 
     - Cuando trabajes con cualquier cosa bajo frontend/
     - Cuando necesites saber como arrancar o testear la aplicacion React
     - Cuando trabajes con componentes, servicios o estilos del frontend
+
+- app_docs/feature-45631491-app-title-rebranding.md
+  - Condiciones:
+    - Cuando se trabaje con el título o branding de la aplicación
+    - Cuando se implemente un cambio de nombre o identidad visual de la app
+    - Cuando se resuelvan problemas relacionados con el texto del encabezado principal o la pestaña del navegador

--- a/app_docs/feature-45631491-app-title-rebranding.md
+++ b/app_docs/feature-45631491-app-title-rebranding.md
@@ -1,0 +1,60 @@
+# Feature: Cambiar título de la aplicación de 'Todo' a '2Do'
+
+**ADW ID:** 45631491
+**Fecha:** 2026-03-05
+**Especificacion:** /mnt/c/Users/amassaguer/Documents/CODE/adw-todo-app-demo/trees/issue-3/.issues/3/plan.md
+
+## Overview
+
+Se actualizó el título y encabezado principal de la aplicación de "Todo List" a "2Do List" para reflejar una identidad visual más distintiva y moderna. El cambio afecta tanto la pestaña del navegador (título HTML) como el encabezado visible de la aplicación (`<h1>`).
+
+## Que se Construyo
+
+- Actualización del título del documento HTML (`<title>`) en `index.html`
+- Actualización del encabezado principal (`<h1>`) en el componente raíz `App.jsx`
+- Actualización del test unitario para reflejar el nuevo título "2Do List"
+
+## Implementacion Tecnica
+
+### Ficheros Modificados
+
+- `frontend/index.html`: Cambiado `<title>Todo List</title>` por `<title>2Do List</title>`
+- `frontend/src/App.jsx`: Cambiado `<h1>Todo List</h1>` por `<h1>2Do List</h1>`
+- `frontend/src/__tests__/App.test.jsx`: Actualizado test name y matcher de `/todo list/i` a `/2do list/i`
+
+### Cambios Clave
+
+- Cambio puramente cosmético/textual sin impacto en lógica de negocio
+- El título del navegador (pestaña) ahora muestra "2Do List" para todos los usuarios
+- El encabezado `<h1>` visible en la UI ahora muestra "2Do List"
+- El test existente `renders Todo List heading` fue renombrado a `renders 2Do List heading` y actualizado para buscar el nuevo texto
+- No se introdujeron nuevas dependencias ni cambios en el backend
+
+## Como Usar
+
+La funcionalidad es transparente para el usuario:
+
+1. Abrir la aplicación en el navegador
+2. La pestaña del navegador mostrará "2Do List"
+3. El encabezado principal de la página mostrará "2Do List"
+
+## Configuracion
+
+No se requiere configuración adicional. El cambio es estático.
+
+## Testing
+
+Ejecutar los tests del frontend para validar el cambio:
+
+```bash
+cd frontend && npm test
+```
+
+El test `renders 2Do List heading` verifica que el encabezado `<h1>` con el texto "2Do List" está presente en el DOM.
+
+## Notas
+
+- No se requieren nuevas dependencias
+- El cambio no afecta al backend ni a la API
+- No hay casos límite relevantes para un cambio de texto estático
+- Si en el futuro se desea cambiar el título nuevamente, modificar `frontend/index.html` y `frontend/src/App.jsx` y actualizar el test correspondiente

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Todo List</title>
+    <title>2Do List</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -40,7 +40,7 @@ function App() {
 
   return (
     <div className="app">
-      <h1>Todo List</h1>
+      <h1>2Do List</h1>
       <TaskForm onTaskCreated={handleCreateTask} />
       <TaskList
         tasks={tasks}

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -11,9 +11,9 @@ vi.mock('../services/api', () => ({
   reorderTasks: vi.fn().mockResolvedValue([])
 }))
 
-test('renders Todo List heading', () => {
+test('renders 2Do List heading', () => {
   render(<App />)
-  const heading = screen.getByRole('heading', { name: /todo list/i })
+  const heading = screen.getByRole('heading', { name: /2do list/i })
   expect(heading).toBeInTheDocument()
 })
 


### PR DESCRIPTION
## Summary
Cambia el título de la aplicación de "Todo List" a "2Do List" en el encabezado principal (`<h1>`) y en el título del documento HTML (pestaña del navegador), junto con la actualización de los tests correspondientes.

Closes #3

## Implementation Plan
See implementation plan in issue #3 comments

## Changes
- `frontend/index.html`: Cambiar `<title>Todo List</title>` por `<title>2Do List</title>`
- `frontend/src/App.jsx`: Cambiar `<h1>Todo List</h1>` por `<h1>2Do List</h1>`
- `frontend/src/__tests__/App.test.jsx`: Actualizar test para buscar "2Do List" en lugar de "Todo List"
- `app_docs/`: Añadir documentación del feature de rebranding del título

## ADW
ADW ID: 45631491
